### PR TITLE
fix: TypeError in logging

### DIFF
--- a/interactions/ext/persistence/persistence.py
+++ b/interactions/ext/persistence/persistence.py
@@ -50,7 +50,7 @@ class Persistence(Extension):
 
         def inner(coro):
             self._component_callbacks[tag] = coro
-            logging.debug("Registered persistent component:", tag)
+            logging.debug(f"Registered persistent component: {tag}")
 
         return inner
 
@@ -66,7 +66,7 @@ class Persistence(Extension):
 
         def inner(coro):
             self._modal_callbacks[tag] = (coro, use_kwargs)
-            logging.debug("Registered persistent modal:", tag)
+            logging.debug(f"Registered persistent modal: {tag}")
 
         return inner
 


### PR DESCRIPTION
Fix "TypeError: not all arguments converted during string formatting"
Turn the logging arguments into f-string as in core bib.