### PR TITLE
fix stacking decorators

### DIFF
--- a/interactions/ext/persistence/client.py
+++ b/interactions/ext/persistence/client.py
@@ -9,7 +9,7 @@ def persistent_component(self, tag: str):
     """
 
     def inner(coro):
-        self.persistence.component(tag)(coro)
+        return self.persistence.component(tag)(coro)
 
     return inner
 
@@ -25,6 +25,6 @@ def persistent_modal(self, tag: str, use_kwargs: bool = False):
     """
 
     def inner(coro):
-        self.persistence.modal(tag, use_kwargs)(coro)
+        return self.persistence.modal(tag, use_kwargs)(coro)
 
     return inner

--- a/interactions/ext/persistence/persistence.py
+++ b/interactions/ext/persistence/persistence.py
@@ -51,6 +51,7 @@ class Persistence(Extension):
         def inner(coro):
             self._component_callbacks[tag] = coro
             logging.debug(f"Registered persistent component: {tag}")
+            return coro
 
         return inner
 
@@ -67,6 +68,7 @@ class Persistence(Extension):
         def inner(coro):
             self._modal_callbacks[tag] = (coro, use_kwargs)
             logging.debug(f"Registered persistent modal: {tag}")
+            return coro
 
         return inner
 


### PR DESCRIPTION
fix component/modal decorators for ability to stacking them.
Add "return coro" statements to pass on the coroutine.

fix issue #13 