### PR TITLE
"Fix" Component iteration

### DIFF
--- a/interactions/ext/persistence/persistence.py
+++ b/interactions/ext/persistence/persistence.py
@@ -85,7 +85,7 @@ class Persistence(Extension):
             pid = PersistentCustomID.from_discord(self._cipher, ctx.custom_id)
         except JSONDecodeError:
             logging.info("Interaction made with invalid persistent custom_id. Skipping.")
-        
+
         if pid.tag in self._component_callbacks:
             await self._component_callbacks[pid.tag](ctx, pid.package)
 
@@ -102,11 +102,12 @@ class Persistence(Extension):
             pid = PersistentCustomID.from_discord(self._cipher, ctx.data.custom_id)
         except JSONDecodeError:
             logging.info("Interaction made with invalid persistent custom_id. Skipping.")
-        
+
         if callback := self._modal_callbacks.get(pid.tag):
             if callback[1] == 0:
-                args = [item["components"][0]["value"] for item in ctx.data.components]
+                args = [item.components[0].value for item in ctx.data.components]
+
                 await self._modal_callbacks[pid.tag][0](ctx, pid.package, *args)
             else:
-                kwargs = {item["components"][0]["custom_id"]: item["components"][0]["value"] for item in ctx.data.components}
+                kwargs = {item.components[0].custom_id: item.components[0].value for item in ctx.data.components}
                 await self._modal_callbacks[pid.tag][0](ctx, pid.package, **kwargs)


### PR DESCRIPTION
I have a modal popup with text boxes. When submitting the modal, I would get an error that `ActionRow` was not subscript-able.

This fixed it for me, but I didn't do any additional investigation. Could be something specific to me I guess, but I wanted to offer the change upstream in case it was a genuine issue.

Please feel free to close if this isn't wanted/needed!